### PR TITLE
feat(avatar): support dynamic hair color in Avatar component

### DIFF
--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -41,6 +41,7 @@ const Avatar = (props: AvatarProps) => {
 
             const svgRawList = await Promise.all(promises);
             let skinColor: string | undefined;
+            let hairColor: string | undefined;
 
             const svgElements = svgRawList.map((svgContent, i) => {
                 if (!svgContent) {
@@ -54,6 +55,10 @@ const Avatar = (props: AvatarProps) => {
                     skinColor = widgetFillColor;
                 }
 
+                if (widgetType === WidgetType.Hair) {
+                    hairColor = widgetFillColor
+                }
+
                 const isFaceWidget = sortedList[i][0] === WidgetType.Face;
                 const isCurlyShort = avatarOption.widgets.hair?.shape === 'curlyShort'
 
@@ -64,7 +69,8 @@ const Avatar = (props: AvatarProps) => {
                 const svgXmlContent = svgContent
                     .slice(svgContent.indexOf('>', svgContent.indexOf('<svg')) + 1)
                     .replace('</svg>', '')
-                    .replaceAll(/\$fillColor/g, skinColor || 'transparent');
+                    .replaceAll(/\$fillColor/g, skinColor || 'transparent')
+                    .replaceAll(/\$hairColor/g, hairColor || 'transparent');
 
                 const transformFace = isFaceWidget ? `transform="${faceTransform}"` : '';
                 const transformHair = isCurlyShort ? `transform="${hairTransform}"` : '';

--- a/utils/modifySvg.ts
+++ b/utils/modifySvg.ts
@@ -1,0 +1,21 @@
+const fetchAndModifySVG = async (importFunction:any, color: string) => {
+  try {
+      const svgModule = await importFunction();
+      console.log('SVG MODULE', svgModule)
+      let svgContent = svgModule.default;
+      const response = await fetch(svgContent.src);
+      svgContent = await response.text();
+
+    if (color) {
+      svgContent = svgContent.replaceAll(/\$hairColor/g, color);
+    }
+
+    return svgContent;
+  } catch (error) {
+    console.error("Error loading SVG: ", error);
+    return null;
+  }
+};
+
+
+export default fetchAndModifySVG


### PR DESCRIPTION
This commit introduces support for dynamic hair color customization in the Avatar component. A new state variable `hairColor` has been added to store the selected hair color. The SVG rendering logic for avatars now replaces `$hairColor` placeholders in SVG content with this value, enabling hair color changes based on user preference.

Additionally, a utility function `fetchAndModifySVG` is added to fetch SVG content and apply the hair color dynamically before rendering. This function offers enhanced flexibility for handling SVG modifications and can be expanded to accommodate additional SVG transformations in the future.