### PR TITLE
feat(scrollbar): add title attribute to list items for improved accessibility

### DIFF
--- a/components/scrollbar/index.tsx
+++ b/components/scrollbar/index.tsx
@@ -172,6 +172,8 @@ const Scrollbar = (props: IProps) => {
                                         className={`${styles.listItem} ${it.widgetShape === avatarOption.widgets?.[s.widgetType]?.shape ? styles.selected : ''}`}
                                         onClick={() => onSetSwitchWidget(s.widgetType, it.widgetShape)}
                                         dangerouslySetInnerHTML={{ __html: it.svgRaw }}
+                                        title={it.widgetShape}
+
                                     />
 
                                 )


### PR DESCRIPTION
Adding the `title` attribute to each list item within the scrollbar component enhances accessibility by providing additional context on hover. This is particularly beneficial for users who rely on assistive technologies or those who prefer to have a tooltip for quick information about the interactive elements on the page.